### PR TITLE
Allow form parameters to contain forward slashes by url encoding the slashes before the full uri encoding

### DIFF
--- a/lib/Net/HTTP/Spore/Request.pm
+++ b/lib/Net/HTTP/Spore/Request.pm
@@ -273,6 +273,7 @@ sub finalize {
     for ( my $i = 0 ; $i < scalar @$params ; $i++ ) {
         my $k = $params->[$i];
         my $v = $params->[++$i];
+        $v    =~ s/\//%2F/g;
         my $modified = 0;
 
         if ($path_info && $path_info =~ s/\:$k/$v/) {

--- a/lib/Net/HTTP/Spore/Request.pm
+++ b/lib/Net/HTTP/Spore/Request.pm
@@ -159,16 +159,12 @@ sub uri {
 
     my $base = $self->_uri_base;
 
-    my $path_escape_class = '^A-Za-z0-9\-\._~/';
-
-    my $path = URI::Escape::uri_escape($path_info || '', $path_escape_class);
-
     if (defined $query_string && length($query_string) > 0) {
-        $path .= '?' . $query_string;
+        $path_info .= '?' . $query_string;
     }
 
-    $base =~ s!/$!! if $path =~ m!^/!;
-    return URI->new( $base . $path )->canonical;
+    $base =~ s!/$!! if $path_info =~ m!^/!;
+    return URI->new( $base . $path_info )->canonical;
 }
 
 sub _path {
@@ -270,9 +266,11 @@ sub finalize {
     my $query = [];
     my $form  = {};
 
+    my $path_escape_class = '^A-Za-z0-9\-\._~/\/';
+
     for ( my $i = 0 ; $i < scalar @$params ; $i++ ) {
         my $k = $params->[$i];
-        my $v = $params->[++$i];
+        my $v = URI::Escape::uri_escape($params->[++$i] || '', $path_escape_class);
         $v    =~ s/\//%2F/g;
         my $modified = 0;
 


### PR DESCRIPTION
This is in response to issues I had with Neo4j. When trying to do a query to Neo4j indices, if the $value contained a forward slash, it would not url encode it. It would also break when trying to add a node to an index. Doing a url encode before passing it to Spore would result in double url encoding.

http://docs.neo4j.org/chunked/snapshot/rest-api-indexes.html#rest-api-find-node-by-exact-match

Let me know if you need further clarification. Thanks!
