### PR TITLE
Support for UTF-8 strings in QUERY_STRING 

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+    - Proper handling of UTF-8 content in query string escaping 
+    - Support for path with question marks in spore specs
+      (Alexis Sukrieh / Weborama)
+
 0.06 Fri Apr 19 15:58::33 2013
     - Fix random test failure in t/spore-method/base.t related to random hash
       ordering in perl 5.17.6+ (#19)


### PR DESCRIPTION
Hello, at Weborama we've patched Spore this way to allow UTF-8 content in query_string.

Would it be possible to merge those changes upstream?

All the tests pass.

Thanks!

Tell me if there's anything wrong here, I'd be happy to adapt the patch accordingly.
