### PR TITLE
Wrap enum values in arrayref (franckcuny/net-http-spore#30)

### DIFF
--- a/lib/Net/HTTP/Spore/Meta/Types.pm
+++ b/lib/Net/HTTP/Spore/Meta/Types.pm
@@ -12,7 +12,7 @@ subtype UriPath,
     where { $_ =~ m!^/! },
     message {"path must start with /"};
 
-enum HTTPMethod, qw(OPTIONS HEAD GET POST PUT DELETE TRACE PATCH);
+enum HTTPMethod, [qw(OPTIONS HEAD GET POST PUT DELETE TRACE PATCH)];
 
 subtype Boolean,
     as Int,


### PR DESCRIPTION
Fix for:

```
Passing a list of values to enum is deprecated.
Enum values should be wrapped in an arrayref.
    at xxxxxx/lib/site_perl/5.16.3/Net/HTTP/Spore/Meta/Types.pm line 18.
```
