### PR TITLE
Add basic middleware for text/plain format

### DIFF
--- a/lib/Net/HTTP/Spore/Middleware/Format/Text.pm
+++ b/lib/Net/HTTP/Spore/Middleware/Format/Text.pm
@@ -1,0 +1,24 @@
+package Net::HTTP::Spore::Middleware::Format::Text;
+
+# ABSTRACT: middleware for Text format
+use Moose;
+extends 'Net::HTTP::Spore::Middleware::Format';
+
+sub encode       { $_[1] }
+sub decode       { $_[1] }
+sub accept_type  { ( 'Accept' => 'text/plain' ) }
+sub content_type { ( 'Content-Type' => 'text/plain' ) }
+
+1;
+
+=head1 SYNOPSIS
+
+    my $client = Net::HTTP::Spore->new_from_spec('twitter.json');
+    $client->enable('Format::Text');
+
+=head1 DESCRIPTION
+
+Net::HTTP::Spore::Middleware::Format::Text is a simple middleware to
+handle requests in C<text/plain> format. It will set the appropriate
+B<Accept> header in your request. If the request method is PUT or
+POST, the B<Content-Type> header will also be set to C<text/plain>.

--- a/t/spore-middleware/format-text.t
+++ b/t/spore-middleware/format-text.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Net::HTTP::Spore;
+
+my $content = 'response';
+my $payload = 'request payload';
+
+my $mock_server = {
+    '/show' => sub {
+        my $req = shift;
+        is( $req->header('Accept'), 'text/plain' );
+        $req->new_response(
+            200,
+            [ 'Content-Type' => 'text/plain' ],
+            $content
+        );
+    },
+    '/add' => sub {
+        my $req = shift;
+        is( $req->header('Content-Type'), 'text/plain' );
+        is( $req->body , $payload );
+        $req->new_response(
+            200,
+            [ 'Content-Type' => 'text/plain' ],
+            $content
+        );
+    },
+};
+
+ok my $client =
+  Net::HTTP::Spore->new_from_spec( 't/specs/api.json',
+    base_url => 'http://localhost:5984' );
+
+$client->enable('Format::Text');
+$client->enable('Mock', tests => $mock_server);
+
+my $res = $client->get_info();
+is $res->[0],        200;
+is $res->[2], $content;
+is $res->header('Content-Type'), 'text/plain';
+
+my $req = $res->request;
+is $req->header('Accept'), 'text/plain';
+
+$res = $client->add_user(payload => $payload);
+is $res->[0], 200;
+
+done_testing;


### PR DESCRIPTION
I have a spec that has one endpoint that requires `text/plain` while the
rest of its endpoints call for `application/json`. Is there a better way
to handle this ?

For now, I made a middleware for the `text/plain` format that is just a
rip off of Format::JSON. Apparently, middleware activation order matters, 
so I have to reset all middlewares and re-apply in the proper order to 
switch between formats while using the same spec.
