### PR TITLE
Fix compatibility with JSON::XS 3.01

### DIFF
--- a/lib/Net/HTTP/Spore/Meta/Types.pm
+++ b/lib/Net/HTTP/Spore/Meta/Types.pm
@@ -24,7 +24,7 @@ subtype JSONBoolean,
 
 coerce Boolean,
     from JSONBoolean,
-      via { return $_ == JSON::true() ? 1 : 0 },
+      via { return int($_) ? 1 : 0 },
     from Str,
       via { return $_ eq 'true' ? 1 : 0 };
 


### PR DESCRIPTION
`==` is no longer overloaded for JSON::true and JSON::false if the user has JSON::XS 3.01 installed; instead we can cast them to integers via int(). We could probably just return `int($_)` but I wanted to make as small a change as possible...
